### PR TITLE
Use new connections style in menubar actions

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -86,8 +86,8 @@ void MainWindow::add_menubar_items() {
     app_menu->addAction(about_action);
     app_menu->addAction(export_action);
 
-    connect(preferences_action, SIGNAL(triggered()), this, SLOT(open_user_settings()));
-    connect(about_action, SIGNAL(triggered()), this, SLOT(open_about_dialog()));
+    connect(preferences_action, &QAction::triggered, this, &MainWindow::open_user_settings);
+    connect(about_action, &QAction::triggered, this, &MainWindow::open_about_dialog);
     connect(export_action, &QAction::triggered, this, &MainWindow::open_export_dialog);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR finishes the migration to the new style of Qt connections.

## Motivation and Context
This was done for future compatibility and to maintain a consistent codebase. This closes issue #208 .

## How Has This Been Tested?
This change has been tested by running the app and ensuring that the menubar actions still work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
