### PR TITLE
Fix text cutoff in export dialog

### DIFF
--- a/src/export_data.ui
+++ b/src/export_data.ui
@@ -33,9 +33,9 @@
    <property name="geometry">
     <rect>
      <x>12</x>
-     <y>30</y>
+     <y>25</y>
      <width>74</width>
-     <height>10</height>
+     <height>20</height>
     </rect>
    </property>
    <property name="text">

--- a/src/ui_export_data.h
+++ b/src/ui_export_data.h
@@ -42,7 +42,7 @@ public:
         exportPathInput->setSizePolicy(sizePolicy);
         exportPathLabel = new QLabel(exportDialog);
         exportPathLabel->setObjectName(QString::fromUtf8("exportPathLabel"));
-        exportPathLabel->setGeometry(QRect(12, 30, 74, 10));
+        exportPathLabel->setGeometry(QRect(12, 25, 74, 20));
         exportPathBrowse = new QPushButton(exportDialog);
         exportPathBrowse->setObjectName(QString::fromUtf8("exportPathBrowse"));
         exportPathBrowse->setGeometry(QRect(447, 21, 87, 32));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The path label in the export dialog window was cut off at the bottom because the height of the label was too short.

## Motivation and Context
This change was implemented to improve the UI.

## How Has This Been Tested?
The changes were tested by viewing the dialog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
