### PR TITLE
Don't count drinks 7 days ago

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -580,12 +580,11 @@ void MainWindow::update_stat_panel() {
         std::cout << "Using fixed date method" << std::endl;
         start_date = todays_date - (date::weekday{todays_date} - filter_day);
         weekday_name = options.weekday_start;
-    } else {
+    } else {  // Don't include day 7 days ago.
         std::cout << "Using rolling date method" << std::endl;
-        start_date = todays_date - date::days{7};
-
+        start_date = todays_date - date::days{6};
         // Get weekday name
-        weekday_name = date::format("%A", date::weekday(start_date));
+        weekday_name = date::format("%A", date::weekday(todays_date - date::days{7}));
     }
 
     std::cout << "Calculating stats since " << start_date << ", which is last " << weekday_name << std::endl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Originally, the code counted 7 full days when doing the rolling date calculation. This means that if you began drinking on Sunday, next Sunday, those drinks would still be counted. Only drinks Monday forward should be counted.

## Motivation and Context
This PR fixes an issue where dates were incorrectly included in the rolling calculation.

## How Has This Been Tested?
This was tested by running the app and viewing the statistics.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
