### PR TITLE
Improve date preferences in dialog

### DIFF
--- a/src/ui_user_settings.h
+++ b/src/ui_user_settings.h
@@ -158,9 +158,9 @@ public:
         weekdayStartInput->setItemText(5, QCoreApplication::translate("userSettingsDialog", "Friday", nullptr));
         weekdayStartInput->setItemText(6, QCoreApplication::translate("userSettingsDialog", "Saturday", nullptr));
 
-        weekdayStartLabel->setText(QCoreApplication::translate("userSettingsDialog", "Week begins on:", nullptr));
-        fixedDateRadioButton->setText(QCoreApplication::translate("userSettingsDialog", "Fixed date", nullptr));
-        rollingDateRadioButton->setText(QCoreApplication::translate("userSettingsDialog", "Rolling date", nullptr));
+        weekdayStartLabel->setText(QCoreApplication::translate("userSettingsDialog", "Reset stats on:", nullptr));
+        fixedDateRadioButton->setText(QCoreApplication::translate("userSettingsDialog", "Reset on day", nullptr));
+        rollingDateRadioButton->setText(QCoreApplication::translate("userSettingsDialog", "Rolling", nullptr));
         sexGroup->setTitle(QCoreApplication::translate("userSettingsDialog", "Sex", nullptr));
         maleSelection->setText(QCoreApplication::translate("userSettingsDialog", "Male", nullptr));
         femaleSelection->setText(QCoreApplication::translate("userSettingsDialog", "Female", nullptr));

--- a/src/user_settings.ui
+++ b/src/user_settings.ui
@@ -80,21 +80,21 @@
          <item row="3" column="0">
           <widget class="QLabel" name="weekdayStartLabel">
            <property name="text">
-            <string>Week begins on:</string>
+            <string>Reset stats on:</string>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
           <widget class="QRadioButton" name="fixedDateRadioButton">
            <property name="text">
-            <string>Fixed date</string>
+            <string>Reset on day</string>
            </property>
           </widget>
          </item>
          <item row="0" column="0">
           <widget class="QRadioButton" name="rollingDateRadioButton">
            <property name="text">
-            <string>Rolling date</string>
+            <string>Rolling</string>
            </property>
            <property name="checked">
             <bool>true</bool>

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -30,12 +30,18 @@ UserSettings::UserSettings(QWidget *parent, const Options& options) {
 
     // Set day of week calc
     if (options.date_calculation_method == "Fixed") {
+        ui.weekdayStartInput->setEnabled(true);
         ui.fixedDateRadioButton->setChecked(true);
         ui.rollingDateRadioButton->setChecked(false);
     } else {
+        ui.weekdayStartInput->setEnabled(false);
         ui.fixedDateRadioButton->setChecked(false);
         ui.rollingDateRadioButton->setChecked(true);
     }
+
+    // Connections
+    connect(ui.rollingDateRadioButton, &QRadioButton::clicked, this, &UserSettings::changed_date_calc);
+    connect(ui.fixedDateRadioButton, &QRadioButton::clicked, this, &UserSettings::changed_date_calc);
 }
 
 std::string UserSettings::get_sex() {
@@ -68,6 +74,18 @@ std::string UserSettings::get_date_calculation_method() {
         return "Rolling";
     } else {
         return "Fixed";
+    }
+}
+
+void UserSettings::changed_date_calc() {
+    /*
+     * Disable/enable weekday start combobox.
+     */
+
+    if (ui.rollingDateRadioButton->isChecked()) {
+        ui.weekdayStartInput->setEnabled(false);
+    } else {
+        ui.weekdayStartInput->setEnabled(true);
     }
 }
 // LCOV_EXCL_STOP

--- a/src/usersettings.h
+++ b/src/usersettings.h
@@ -20,6 +20,9 @@ public:
     std::string get_sex();
     std::string get_weekday_start();
     std::string get_date_calculation_method();
+
+private slots:
+    void changed_date_calc();
 };
 
 #endif //BEERTABS_USERSETTINGS_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disable fixed start day if rolling date method is selected. Also moved around the widgets so that they are better looking.

## Motivation and Context
This was changed to improve the UI.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has been tested by viewing the settings dialog, changing the settings, and verifying that it behaves as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
