### PR TITLE
Greater ranges for input fields

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -568,7 +568,7 @@
        </sizepolicy>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="beerTab">
        <attribute name="title">
@@ -803,6 +803,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
            </widget>
           </item>
           <item row="1" column="3">
@@ -876,6 +879,9 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -985,6 +991,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -1039,6 +1048,9 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
             </property>
            </widget>
           </item>
@@ -1235,6 +1247,9 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
            </widget>
           </item>
           <item row="1" column="2">
@@ -1273,6 +1288,9 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
             </property>
            </widget>
           </item>

--- a/src/ui_mainwindow.h
+++ b/src/ui_mainwindow.h
@@ -576,6 +576,7 @@ public:
         beerSizeInput->setObjectName(QString::fromUtf8("beerSizeInput"));
         sizePolicy1.setHeightForWidth(beerSizeInput->sizePolicy().hasHeightForWidth());
         beerSizeInput->setSizePolicy(sizePolicy1);
+        beerSizeInput->setMaximum(9999);
 
         gridLayout_3->addWidget(beerSizeInput, 2, 3, 1, 1);
 
@@ -616,6 +617,7 @@ public:
         beerAbvInput->setObjectName(QString::fromUtf8("beerAbvInput"));
         sizePolicy1.setHeightForWidth(beerAbvInput->sizePolicy().hasHeightForWidth());
         beerAbvInput->setSizePolicy(sizePolicy1);
+        beerAbvInput->setMaximum(100.000000000000000);
 
         gridLayout_3->addWidget(beerAbvInput, 2, 0, 1, 1);
 
@@ -675,6 +677,7 @@ public:
         liquorAbvInput->setObjectName(QString::fromUtf8("liquorAbvInput"));
         sizePolicy1.setHeightForWidth(liquorAbvInput->sizePolicy().hasHeightForWidth());
         liquorAbvInput->setSizePolicy(sizePolicy1);
+        liquorAbvInput->setMaximum(100.000000000000000);
 
         gridLayout_6->addWidget(liquorAbvInput, 2, 0, 1, 1);
 
@@ -706,6 +709,7 @@ public:
         liquorSizeInput->setObjectName(QString::fromUtf8("liquorSizeInput"));
         sizePolicy1.setHeightForWidth(liquorSizeInput->sizePolicy().hasHeightForWidth());
         liquorSizeInput->setSizePolicy(sizePolicy1);
+        liquorSizeInput->setMaximum(9999);
 
         gridLayout_6->addWidget(liquorSizeInput, 2, 2, 1, 1);
 
@@ -817,6 +821,7 @@ public:
         wineSizeInput->setObjectName(QString::fromUtf8("wineSizeInput"));
         sizePolicy1.setHeightForWidth(wineSizeInput->sizePolicy().hasHeightForWidth());
         wineSizeInput->setSizePolicy(sizePolicy1);
+        wineSizeInput->setMaximum(9999);
 
         gridLayout_9->addWidget(wineSizeInput, 2, 3, 1, 1);
 
@@ -840,6 +845,7 @@ public:
         wineAbvInput->setObjectName(QString::fromUtf8("wineAbvInput"));
         sizePolicy1.setHeightForWidth(wineAbvInput->sizePolicy().hasHeightForWidth());
         wineAbvInput->setSizePolicy(sizePolicy1);
+        wineAbvInput->setMaximum(100.000000000000000);
 
         gridLayout_9->addWidget(wineAbvInput, 2, 1, 1, 1);
 
@@ -999,7 +1005,7 @@ public:
 
         retranslateUi(MainWindow);
 
-        tabWidget->setCurrentIndex(0);
+        tabWidget->setCurrentIndex(2);
 
 
         QMetaObject::connectSlotsByName(MainWindow);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow higher ranges of input values for input fields. Up to 9999 for IBU, up to 100% for ABV, up to 9999 for size.

## Motivation and Context
This allows more flexibility in input. This closes issue #151 .

## How Has This Been Tested?
The changes were tested by running unit tests and by running the app and entering values in the extended range.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
