### PR TITLE
Don't update or clear names when updating producer or type

### DIFF
--- a/src/beer.cpp
+++ b/src/beer.cpp
@@ -112,7 +112,7 @@ void MainWindow::update_beer_names_producers() {
     ui->beerIbuInput->setValue(0.0);
     ui->beerSizeInput->setValue(0);
     ui->beerRatingInput->setValue(0);
-    ui->beerNameInput->clear();
+    //ui->beerNameInput->clear();
     ui->beerBreweryInput->clear();
 
     for (const auto& selected_beer : selected_beers) {
@@ -124,9 +124,9 @@ void MainWindow::update_beer_names_producers() {
         ui->beerBreweryInput->addItem(brewery);
     }
 
-    for (const auto& beer : drink_names) {
-        ui->beerNameInput->addItem(beer);
-    }
+    //for (const auto& beer : drink_names) {
+    //    ui->beerNameInput->addItem(beer);
+    //}
 }
 
 void MainWindow::update_beer_names_types() {
@@ -149,7 +149,7 @@ void MainWindow::update_beer_names_types() {
     ui->beerIbuInput->setValue(0.0);
     ui->beerSizeInput->setValue(0);
     ui->beerRatingInput->setValue(0);
-    ui->beerNameInput->clear();
+    //ui->beerNameInput->clear();
     ui->beerTypeInput->clear();
     ui->beerSubtypeInput->clear();
 
@@ -158,9 +158,9 @@ void MainWindow::update_beer_names_types() {
         types.insert(QString::fromStdString(selected_beer.type));
     }
 
-    for (const auto& name : beer_names) {
-        ui->beerNameInput->addItem(name);
-    }
+    //for (const auto& name : beer_names) {
+    //    ui->beerNameInput->addItem(name);
+    //}
 
     for (const auto& beer_type : types) {
         ui->beerTypeInput->addItem(beer_type);
@@ -186,7 +186,7 @@ void MainWindow::update_beer_types_producers() {
     std::cout << "ID " << selected_beer.id << std::endl;
 
     if (!selected_beer.id || selected_beer.id == -1) {  // Clear fields if new name
-        clear_fields("Beer");
+        //clear_fields("Beer");
     } else {
         std::string beer_type = selected_beer.type;
         std::string beer_subtype = selected_beer.subtype;

--- a/src/liquor.cpp
+++ b/src/liquor.cpp
@@ -116,7 +116,7 @@ void MainWindow::update_liquor_names_producers() {
     ui->liquorAbvInput->setValue(0.0);
     ui->liquorSizeInput->setValue(0);
     ui->liquorRatingInput->setValue(0);
-    ui->liquorNameInput->clear();
+    //ui->liquorNameInput->clear();
     ui->liquorDistillerInput->clear();
 
     for (const auto& selected_drink : selected_drinks) {
@@ -128,9 +128,9 @@ void MainWindow::update_liquor_names_producers() {
         ui->liquorDistillerInput->addItem(distillery);
     }
 
-    for (const auto& drink_name : drink_names) {
-        ui->liquorNameInput->addItem(drink_name);
-    }
+    //for (const auto& drink_name : drink_names) {
+    //    ui->liquorNameInput->addItem(drink_name);
+    //}
 }
 
 void MainWindow::update_liquor_names_types() {
@@ -152,7 +152,7 @@ void MainWindow::update_liquor_names_types() {
     ui->liquorAbvInput->setValue(0.0);
     ui->liquorSizeInput->setValue(0);
     ui->liquorRatingInput->setValue(0);
-    ui->liquorNameInput->clear();
+    //ui->liquorNameInput->clear();
     ui->liquorTypeInput->clear();
     ui->liquorSubtypeInput->clear();
 
@@ -162,9 +162,9 @@ void MainWindow::update_liquor_names_types() {
         subtypes.insert(QString::fromStdString(selected_drink.subtype));
     }
 
-    for (const auto& name : liquor_names) {
-        ui->liquorNameInput->addItem(name);
-    }
+    //for (const auto& name : liquor_names) {
+    //    ui->liquorNameInput->addItem(name);
+    //}
 
     for (const auto& liquor_type : types) {
         ui->liquorTypeInput->addItem(liquor_type);
@@ -188,7 +188,7 @@ void MainWindow::update_liquor_types_producers() {
     Drink selected_liquor = Database::get_drink_by_name(storage, "Liquor",input_liquor);
 
     if (!selected_liquor.id || selected_liquor.id == -1) {
-        clear_fields("Liquor");
+        //clear_fields("Liquor");
     } else {
         std::string liquor_type = selected_liquor.type;
         std::string liquor_subtype = selected_liquor.subtype;

--- a/src/wine.cpp
+++ b/src/wine.cpp
@@ -116,7 +116,7 @@ void MainWindow::update_wine_names_producers() {
     ui->wineAbvInput->setValue(0.0);
     ui->wineSizeInput->setValue(0);
     ui->wineRatingInput->setValue(0);
-    ui->wineNameInput->clear();
+    //ui->wineNameInput->clear();
     ui->wineryInput->clear();
 
     for (const auto& selected_drink : selected_drinks) {
@@ -128,9 +128,9 @@ void MainWindow::update_wine_names_producers() {
         ui->wineryInput->addItem(winery);
     }
 
-    for (const auto& drink_name : drink_names) {
-        ui->wineNameInput->addItem(drink_name);
-    }
+    //for (const auto& drink_name : drink_names) {
+    //    ui->wineNameInput->addItem(drink_name);
+    //}
 }
 
 void MainWindow::update_wine_names_types() {
@@ -152,7 +152,7 @@ void MainWindow::update_wine_names_types() {
     ui->wineAbvInput->setValue(0.0);
     ui->wineSizeInput->setValue(0);
     ui->wineRatingInput->setValue(0);
-    ui->wineNameInput->clear();
+    //ui->wineNameInput->clear();
     ui->wineTypeInput->clear();
     ui->wineSubtypeInput->clear();
 
@@ -162,9 +162,9 @@ void MainWindow::update_wine_names_types() {
         subtypes.insert(QString::fromStdString(selected_drink.subtype));
     }
 
-    for (const auto& name : wine_names) {
-        ui->wineNameInput->addItem(name);
-    }
+    //for (const auto& name : wine_names) {
+    //    ui->wineNameInput->addItem(name);
+    //}
 
     for (const auto& wine_type : types) {
         ui->wineTypeInput->addItem(wine_type);
@@ -189,7 +189,7 @@ void MainWindow::update_wine_types_producers() {
     Drink selected_wine = Database::get_drink_by_name(storage, "Wine",input_wine);
 
     if (!selected_wine.id || selected_wine.id == -1) {
-        clear_fields("Wine");
+        //clear_fields("Wine");
     } else {
         std::string wine_type = selected_wine.type;
         std::string wine_subtype = selected_wine.subtype;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the name would be overwritten when entering a new drink for an existing producer or type. Code that populates or clears the name fields when updating the producer or type inputs was commented out for now.

## Motivation and Context
This PR fixes an issue where the name would be overwritten when entering a new drink for an existing producer or type.
This closes issue #246 .

## How Has This Been Tested?
The changes were tested by entering new drinks on an existing producer & type.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
