### PR TITLE
Fix problems with entering new drink with same producer

### DIFF
--- a/src/beer.cpp
+++ b/src/beer.cpp
@@ -186,7 +186,7 @@ void MainWindow::update_beer_types_producers() {
     std::cout << "ID " << selected_beer.id << std::endl;
 
     if (!selected_beer.id || selected_beer.id == -1) {  // Clear fields if new name
-        //clear_fields("Beer");
+        clear_fields("Beer");
     } else {
         std::string beer_type = selected_beer.type;
         std::string beer_subtype = selected_beer.subtype;

--- a/src/liquor.cpp
+++ b/src/liquor.cpp
@@ -188,7 +188,7 @@ void MainWindow::update_liquor_types_producers() {
     Drink selected_liquor = Database::get_drink_by_name(storage, "Liquor",input_liquor);
 
     if (!selected_liquor.id || selected_liquor.id == -1) {
-        //clear_fields("Liquor");
+        clear_fields("Liquor");
     } else {
         std::string liquor_type = selected_liquor.type;
         std::string liquor_subtype = selected_liquor.subtype;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -981,41 +981,46 @@ void MainWindow::clear_fields(const std::string& alcohol_type) {
 
     // Do not clear names!
 
-    if (alcohol_type == "Beer") {
-        //ui->beerBreweryInput->clear();
-        ui->beerBreweryInput->setCurrentText("");
-        //ui->beerTypeInput->clear();
-        ui->beerTypeInput->setCurrentText("");
-        //ui->beerSubtypeInput->clear();
-        ui->beerSubtypeInput->setCurrentText("");
-        ui->beerAbvInput->clear();
-        ui->beerIbuInput->clear();
-        ui->beerSizeInput->clear();
-        ui->beerRatingInput->clear();
-        ui->beerNotesInput->clear();
-    } else if (alcohol_type == "Liquor") {
-        //ui->liquorDistillerInput->clear();
-        ui->liquorDistillerInput->setCurrentText("");
-        //ui->liquorTypeInput->clear();
-        ui->liquorTypeInput->setCurrentText("");
-        //ui->liquorSubtypeInput->clear();
-        ui->liquorSubtypeInput->setCurrentText("");
-        ui->liquorAbvInput->clear();
-        ui->liquorSizeInput->clear();
-        ui->liquorRatingInput->clear();
-        ui->liquorNotesInput->clear();
-    } else if (alcohol_type == "Wine") {
-        //ui->wineryInput->clear();
-        ui->wineryInput->setCurrentText("");
-        //ui->wineTypeInput->clear();
-        ui->wineTypeInput->setCurrentText("");
-        //ui->wineSubtypeInput->clear();
-        ui->wineSubtypeInput->setCurrentText("");
-        ui->wineVintage->clear();
-        ui->wineAbvInput->clear();
-        ui->wineRatingInput->clear();
-        ui->wineSizeInput->clear();
-        ui->wineNotesInput->clear();
+    QItemSelectionModel *selection_model = ui->drinkLogTable->selectionModel();
+    QModelIndexList selected_rows = selection_model->selectedRows();
+
+    if (selected_rows.empty()) {
+        if (alcohol_type == "Beer") {
+            //ui->beerBreweryInput->clear();
+            //ui->beerBreweryInput->setCurrentText("");
+            //ui->beerTypeInput->clear();
+            //ui->beerTypeInput->setCurrentText("");
+            //ui->beerSubtypeInput->clear();
+            //ui->beerSubtypeInput->setCurrentText("");
+            ui->beerAbvInput->clear();
+            ui->beerIbuInput->clear();
+            ui->beerSizeInput->clear();
+            ui->beerRatingInput->clear();
+            ui->beerNotesInput->clear();
+        } else if (alcohol_type == "Liquor") {
+            //ui->liquorDistillerInput->clear();
+            //ui->liquorDistillerInput->setCurrentText("");
+            //ui->liquorTypeInput->clear();
+            //ui->liquorTypeInput->setCurrentText("");
+            //ui->liquorSubtypeInput->clear();
+            //ui->liquorSubtypeInput->setCurrentText("");
+            ui->liquorAbvInput->clear();
+            ui->liquorSizeInput->clear();
+            ui->liquorRatingInput->clear();
+            ui->liquorNotesInput->clear();
+        } else if (alcohol_type == "Wine") {
+            //ui->wineryInput->clear();
+            //ui->wineryInput->setCurrentText("");
+            //ui->wineTypeInput->clear();
+            //ui->wineTypeInput->setCurrentText("");
+            //ui->wineSubtypeInput->clear();
+            //ui->wineSubtypeInput->setCurrentText("");
+            ui->wineVintage->clear();
+            ui->wineAbvInput->clear();
+            ui->wineRatingInput->clear();
+            ui->wineSizeInput->clear();
+            ui->wineNotesInput->clear();
+        }
     }
 }
 

--- a/src/wine.cpp
+++ b/src/wine.cpp
@@ -189,7 +189,7 @@ void MainWindow::update_wine_types_producers() {
     Drink selected_wine = Database::get_drink_by_name(storage, "Wine",input_wine);
 
     if (!selected_wine.id || selected_wine.id == -1) {
-        //clear_fields("Wine");
+        clear_fields("Wine");
     } else {
         std::string wine_type = selected_wine.type;
         std::string wine_subtype = selected_wine.subtype;


### PR DESCRIPTION
Clear ABV, IBU, etc. fields when entering new drink, but don't do it if a row is selected.

These changes prevent clearing brewery, type, or subtype fields, and the program now only clears fields if a row isn't selected.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
This fixes issues with entering a new drink by the same producer.

## How Has This Been Tested?
This has been tested by running the app and making sure the app behaves as expected when entering a new drink by an existing producer.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
