### PR TITLE
Select entire row when user clicks cell

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,6 +26,9 @@ MainWindow::MainWindow(QWidget *parent)
 
     ui->setupUi(this);
 
+    // Select entire row vs just a cell
+    ui->drinkLogTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+
     // Read options and create if the file doesn't exist
     // TODO: Create the settings file within program_options()
     program_options(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added `ui->drinkLogTable->setSelectionBehavior(QAbstractItemView::SelectRows);` to select the entire row when user clicks a cell.

## Motivation and Context
This fixes issues where users can click a cell and try to edit the row, which crashes the app. This closes issue #255.

## How Has This Been Tested?
Tested the UI and ran unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
