### PR TITLE
Bugfix/integer sorting

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "mainwindow.h"
+#include "iostream"
 
 std::vector<std::set<QString>> MainWindow::generate_filter_item_sets() {
     /*
@@ -74,8 +75,19 @@ void MainWindow::populate_filter_menus(const std::string& filter_type) {
             ui->filterTextInput->addItem(brewery);
         }
     } else if (filter_type == "Rating") {
-        for (const auto& rating : filter_values.at(4)) {
-            ui->filterTextInput->addItem(rating);
+        // Convert rating integers to QStrings and put in set
+        std::vector<int> ratings_tmp;
+        for (const auto& rating_value : filter_values.at(4)) {
+            int rating_int = std::stoi(rating_value.toStdString());
+            ratings_tmp.push_back(rating_int);
+        }
+
+        // Sort ratings in descending order
+        std::sort(ratings_tmp.begin(), ratings_tmp.end(), std::greater<int>());
+
+        for (const auto& rating : ratings_tmp) {
+            QString rating_qstring = QString::fromStdString(std::to_string(rating));
+            ui->filterTextInput->addItem(rating_qstring);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added code in `populate_filter_menus()` that adds filter values as integers to a vector, sorts them in descending order, and then converts them back to QStrings before adding to the rating QComboBox. This makes the QComboBox list the values in descending order instead of alphabetically.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was made because the rating filter values were being displayed alphabetically, e.g. 10, 1, 2, 3... This change makes them appear sorted, like 10, 9, 8...
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
All unit tests were successfully run. The app was inspected visually as well. Everything works as expected.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
