### PR TITLE
Make new column refer to new `size` parameter of `Drink`

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -28,7 +28,7 @@ inline auto initStorage(const std::string& file_name, int db_version) {
                                                           sqlite_orm::make_column("abv", &Drink::abv),
                                                           sqlite_orm::make_column("ibu", &Drink::ibu),
                                                           sqlite_orm::make_column("_size", &Drink::_size, sqlite_orm::default_value(0.0)),
-                                                          sqlite_orm::make_column("size", &Drink::_size, sqlite_orm::default_value(0.0)),
+                                                          sqlite_orm::make_column("size", &Drink::size, sqlite_orm::default_value(0.0)),
                                                           sqlite_orm::make_column("rating", &Drink::rating),
                                                           sqlite_orm::make_column("notes", &Drink::notes),
                                                           sqlite_orm::make_column("vintage", &Drink::vintage, sqlite_orm::default_value(-999)),

--- a/src/drink.h
+++ b/src/drink.h
@@ -19,7 +19,8 @@ private:
     std::string producer;
     double abv;
     double ibu;
-    double _size;  // TODO: Rename to size
+    double _size;  // TODO: Remove after moving to size column
+    double size;
     int rating;
     std::string notes;
     int vintage;


### PR DESCRIPTION
New DB column was referring to the old `_size` parameter of the `Drink` class. This change fixes it to refer to the `size` parameter. This fixes broken graph functionality.