### PR TITLE
Don't create shared_ptr and cstring of week number

### DIFF
--- a/src/graphing_calculations.cpp
+++ b/src/graphing_calculations.cpp
@@ -130,9 +130,7 @@ int GraphingCalculations::date_from_week_num(const std::string& week_num) {
 
     struct tm tm{};
     const std::string week_num_tmp {week_num + "-1"};
-    auto week_char = std::make_unique<char[]>(week_num_tmp.length() + 1);
-    strcpy(week_char.get(), week_num_tmp.c_str());
-    strptime(week_char.get(), "%Y-%W-%w", &tm);
+    strptime(week_num_tmp.c_str(), "%Y-%W-%w", &tm);
 
     std::string year {std::to_string(tm.tm_year +1900)};
     std::string month {std::to_string(tm.tm_mon + 1)};

--- a/src/graphing_calculations.cpp
+++ b/src/graphing_calculations.cpp
@@ -130,7 +130,7 @@ int GraphingCalculations::date_from_week_num(const std::string& week_num) {
 
     struct tm tm{};
     const std::string week_num_tmp {week_num + "-1"};
-    auto week_char {std::make_unique<char>(week_num_tmp.length() + 1)};
+    auto week_char = std::make_unique<char[]>(week_num_tmp.length() + 1);
     strcpy(week_char.get(), week_num_tmp.c_str());
     strptime(week_char.get(), "%Y-%W-%w", &tm);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change removes some redundant code that was also causing a buffer overflow error referenced in #422 .

## Description
<!--- Describe your changes in detail -->
Removed code that created a shared pointer and copied a string into that shared pointer which was then passed into `strptime`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes issue #422.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The app was run and all unit tests executed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
