### PR TITLE
Fix double comparisons to clean up compiler warnings

### DIFF
--- a/src/calculate.cpp
+++ b/src/calculate.cpp
@@ -339,3 +339,14 @@ void Calculate::decrement_day(std::tm &date) {
     date.tm_mon = search_date->tm_mon;
     date.tm_mday = search_date->tm_mday;
 }
+
+bool Calculate::equal_double(const double a, const double b) {
+    /*
+     * Compare two floats.
+     * @param a: Float A
+     * @param b: Float B
+     * @return: Boolean denoting whether a == b
+     */
+
+    return fabs(a - b) < std::numeric_limits<double>::epsilon();
+}

--- a/src/calculate.h
+++ b/src/calculate.h
@@ -26,6 +26,7 @@ public:
     static bool compare_strings(std::string lhs, std::string rhs);
     static int weekly_limit(const Options& options);
     static int days_in_row(Storage &storage);
+    static bool equal_double(const double a, const double b);
 
 private:
     static void decrement_day(std::tm &date);

--- a/test/test_calculations.cpp
+++ b/test/test_calculations.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "../src/calculate.h"
-//#include "../src/mainwindow.h"
 #include <filesystem>
 #include <iostream>
 #if __has_include("catch2/catch_test_macros.hpp")
@@ -28,10 +27,10 @@ TEST_CASE("Standard Drinks", "[Drink Calculations]") {
     asahi.set_abv(5.2);
     asahi.set_size(12);
 
-    REQUIRE(mosaic.get_standard_drinks() == 1.72);
-    REQUIRE(etrwo.get_standard_drinks() == 1.30);
-    REQUIRE(old_rasputin.get_standard_drinks() == 1.80);
-    REQUIRE(asahi.get_standard_drinks() == 1.04);
+    REQUIRE(Calculate::equal_double(mosaic.get_standard_drinks(), 1.72));
+    REQUIRE(Calculate::equal_double(etrwo.get_standard_drinks(), 1.30));
+    REQUIRE(Calculate::equal_double(old_rasputin.get_standard_drinks(), 1.80));
+    REQUIRE(Calculate::equal_double(asahi.get_standard_drinks(), 1.04));
 }
 
 TEST_CASE("Oz Alcohol", "[Drink Calculations]") {
@@ -47,9 +46,9 @@ TEST_CASE("Oz Alcohol", "[Drink Calculations]") {
     old_rasputin.set_abv(9);
     old_rasputin.set_size(12);
 
-    REQUIRE(mosaic.get_alcohol_volume() == 1.032);
-    REQUIRE(etrwo.get_alcohol_volume() == 0.78);
-    REQUIRE(old_rasputin.get_alcohol_volume() == 1.08);
+    REQUIRE(Calculate::equal_double(mosaic.get_alcohol_volume(), 1.032));
+    REQUIRE(Calculate::equal_double(etrwo.get_alcohol_volume(), 0.78));
+    REQUIRE(Calculate::equal_double(old_rasputin.get_alcohol_volume(), 1.08));
 }
 
 TEST_CASE("Std Drinks Remaining - male, NIAAA", "[Drink Calculations]") {
@@ -60,7 +59,7 @@ TEST_CASE("Std Drinks Remaining - male, NIAAA", "[Drink Calculations]") {
 
     double male_drinks_remaining = Calculate::standard_drinks_remaining(options, 4.6);
 
-    REQUIRE(male_drinks_remaining == 9.4);
+    REQUIRE(Calculate::equal_double(male_drinks_remaining, 9.4));
 }
 
 TEST_CASE("Std Drinks Remaining - female, Custom", "[Drink Calculations]") {
@@ -70,7 +69,7 @@ TEST_CASE("Std Drinks Remaining - female, Custom", "[Drink Calculations]") {
     options.weekly_limit = 5;
 
     double female_drinks_remaining = Calculate::standard_drinks_remaining(options, 8);
-    REQUIRE(female_drinks_remaining == -3.0);
+    REQUIRE(Calculate::equal_double(female_drinks_remaining, -3.0));
 }
 
 TEST_CASE("Std Drinks Remaining - female, NIAAA 1", "[Drink Calculations]") {
@@ -80,7 +79,7 @@ TEST_CASE("Std Drinks Remaining - female, NIAAA 1", "[Drink Calculations]") {
     options.weekly_limit = 0;
 
     double female_drinks_remaining_2 = Calculate::standard_drinks_remaining(options, 4);
-    REQUIRE(female_drinks_remaining_2 == 3);
+    REQUIRE(Calculate::equal_double(female_drinks_remaining_2, 3));
 }
 
 TEST_CASE("Std Drinks Remaining - female, NIAAA 2", "[Drink Calculations]") {
@@ -91,7 +90,7 @@ TEST_CASE("Std Drinks Remaining - female, NIAAA 2", "[Drink Calculations]") {
 
     double female_drinks_remaining_3 = Calculate::standard_drinks_remaining(options, 12);
 
-    REQUIRE(female_drinks_remaining_3 == -5);
+    REQUIRE(Calculate::equal_double(female_drinks_remaining_3, -5));
 }
 
 TEST_CASE("Oz Alcohol Remaining", "[Drink Calculations]") {
@@ -106,8 +105,8 @@ TEST_CASE("Oz Alcohol Remaining", "[Drink Calculations]") {
     options.weekly_limit = 10;
     double female_oz_remaining = Calculate::volume_alcohol_remaining(options, 5.5);
 
-    REQUIRE(male_oz_remaining == 4.1);
-    REQUIRE(female_oz_remaining == 0.5);
+    REQUIRE(Calculate::equal_double(male_oz_remaining, 4.1));
+    REQUIRE(Calculate::equal_double(female_oz_remaining, 0.5));
 }
 
 TEST_CASE("Mean ABV", "[Drink Calculations]") {
@@ -180,7 +179,7 @@ TEST_CASE("Mean ABV", "[Drink Calculations]") {
     Database::write_db_to_disk(storage_1);
     double mean_abv = Calculate::mean_abv(storage_1, "Beer");
 
-    REQUIRE(mean_abv == 8.13);
+    REQUIRE(Calculate::equal_double(mean_abv, 8.13));
 }
 
 TEST_CASE("Mean IBU", "[Drink Calculations]") {
@@ -254,7 +253,7 @@ TEST_CASE("Mean IBU", "[Drink Calculations]") {
     Database::write_db_to_disk(storage_1);
     double mean_ibu = Calculate::mean_ibu(storage_1, "Beer");
 
-    REQUIRE(mean_ibu == 65);
+    REQUIRE(Calculate::equal_double(mean_ibu, 65));
 }
 
 TEST_CASE("Favorite Brewery", "[Favorite Calculations]") {

--- a/test/test_database_functions.cpp
+++ b/test/test_database_functions.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "../src/database.h"
+#include "../src/calculate.h"
 #include <cstdio>
 #include <iostream>
 #include <sys/stat.h>
@@ -286,7 +287,7 @@ TEST_CASE("Read Row", "[DB Functions]") {
 
     REQUIRE(mosaic_read.get_id() == 2);
     REQUIRE(mosaic_read.get_name() == "Mosaic");
-    REQUIRE(mosaic.get_abv() == 8.4);
+    REQUIRE(Calculate::equal_double(mosaic.get_abv(), 8.4));
     REQUIRE(etrwo_read.get_id() == 1);
     REQUIRE(etrwo_read.get_ibu() == 60.0);
     REQUIRE(etrwo_read.get_notes() == "Very good hazy IPA.");

--- a/test/test_graph_calculations.cpp
+++ b/test/test_graph_calculations.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "src/graphing_calculations.h"
-#include <iostream>
 #include <map>
 #if __has_include("catch2/catch_test_macros.hpp")
 #include <catch2/catch_test_macros.hpp>

--- a/test/test_graph_calculations.cpp
+++ b/test/test_graph_calculations.cpp
@@ -19,7 +19,7 @@ TEST_CASE("IBU Vector Creation", "[Graph Data Compilation]") {
     Drink etrwo2;
     Drink titos;
 
-    etrwo.set_id(-1); // 1
+    etrwo.set_id(-1);
     etrwo.set_date("2020-09-08");
     etrwo.set_name("Everything Rhymes with Orange");
     etrwo.set_type("IPA");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new function, `equal_double` to compare doubles. This will eliminate floating point comparison warnings when compiling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves issue #406 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All unit tests were successfully run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
