### PR TITLE
Disable macOS sandboxing

### DIFF
--- a/BuzzBot-Entitlements.plist
+++ b/BuzzBot-Entitlements.plist
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
     <key>com.apple.security.app-sandbox</key>
-    <true/>
+    <false/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.files.user-selected.read-write</key>
+    <key>com.apple.security.files.all</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is required so we can write outside of the expected data location