### PR TITLE
Remove boost dependency

### DIFF
--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -16,7 +16,6 @@
 #ifdef __linux
 
 #include <chrono>
-#include <boost/format.hpp>
 
 #endif
 
@@ -72,8 +71,7 @@ std::string utilities::get_local_date() {
     std::ostringstream day_ss;
     day_ss << std::setw(2) << std::setfill('0') << now_tm.tm_mday;
     std::string formatted_day{day_ss.str()};
-
-    output = boost::str(boost::format("%1%-%2%-%3%") % year % formatted_month % formatted_day);
+    output = std::to_string(year) + "-" + formatted_month + "-" + formatted_day;
 #endif
 
     return output;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change removes the unnecessary use of `boost::format` when creating the date output.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This helps builds as we  no longer need to compile boost.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The app was run and all unit tests successfully run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
